### PR TITLE
Add i64/u64 TypeScript number aliases for Rust integer bindings

### DIFF
--- a/dioxus-use-js-macro/src/lib.rs
+++ b/dioxus-use-js-macro/src/lib.rs
@@ -530,6 +530,8 @@ fn ts_type_to_rust_type_helper(mut ts_type: &str, can_be_ref: bool) -> Option<St
             }
         }
         "number" => Some("f64".to_owned()),
+        "i64" => Some("i64".to_owned()),
+        "u64" => Some("u64".to_owned()),
         "boolean" => Some("bool".to_owned()),
         "void" | "undefined" | "never" | "null" => Some(UNIT.to_owned()),
         JSON => {
@@ -2302,6 +2304,10 @@ mod tests {
             ts_type_to_rust_type(Some("number"), true).to_string(),
             "f64"
         );
+        assert_eq!(ts_type_to_rust_type(Some("i64"), false).to_string(), "i64");
+        assert_eq!(ts_type_to_rust_type(Some("i64"), true).to_string(), "i64");
+        assert_eq!(ts_type_to_rust_type(Some("u64"), false).to_string(), "u64");
+        assert_eq!(ts_type_to_rust_type(Some("u64"), true).to_string(), "u64");
         assert_eq!(
             ts_type_to_rust_type(Some("boolean"), false).to_string(),
             "bool"
@@ -2331,6 +2337,14 @@ mod tests {
             "Option<f64>"
         );
         assert_eq!(
+            ts_type_to_rust_type(Some("i64 | null"), true).to_string(),
+            "Option<i64>"
+        );
+        assert_eq!(
+            ts_type_to_rust_type(Some("u64 | null"), false).to_string(),
+            "Option<u64>"
+        );
+        assert_eq!(
             ts_type_to_rust_type(Some("boolean | null"), true).to_string(),
             "Option<bool>"
         );
@@ -2357,6 +2371,14 @@ mod tests {
         assert_eq!(
             ts_type_to_rust_type(Some("Array<number>"), false).to_string(),
             "Vec<f64>"
+        );
+        assert_eq!(
+            ts_type_to_rust_type(Some("Array<u64>"), true).to_string(),
+            "&[u64]"
+        );
+        assert_eq!(
+            ts_type_to_rust_type(Some("Array<u64>"), false).to_string(),
+            "Vec<u64>"
         );
     }
 
@@ -2522,6 +2544,14 @@ mod tests {
             ts_type_to_rust_type(Some("Map<number, string>"), false).to_string(),
             "std::collections::HashMap<f64, String>"
         );
+        assert_eq!(
+            ts_type_to_rust_type(Some("Map<u64, string>"), true).to_string(),
+            "&std::collections::HashMap<u64, String>"
+        );
+        assert_eq!(
+            ts_type_to_rust_type(Some("Map<u64, string>"), false).to_string(),
+            "std::collections::HashMap<u64, String>"
+        );
     }
 
     #[test]
@@ -2541,6 +2571,14 @@ mod tests {
         assert_eq!(
             ts_type_to_rust_type(Some("Set<number>"), false).to_string(),
             "std::collections::HashSet<f64>"
+        );
+        assert_eq!(
+            ts_type_to_rust_type(Some("Set<i64>"), true).to_string(),
+            "&std::collections::HashSet<i64>"
+        );
+        assert_eq!(
+            ts_type_to_rust_type(Some("Set<i64>"), false).to_string(),
+            "std::collections::HashSet<i64>"
         );
         assert_eq!(
             ts_type_to_rust_type(Some("Set<boolean>"), true).to_string(),
@@ -2635,6 +2673,36 @@ mod tests {
         assert_eq!(
             ts_type_to_rust_type(Some("JsValue | null"), false).to_string(),
             "Option<dioxus_use_js::JsValue>"
+        );
+    }
+
+    #[test]
+    fn test_type_alias_names_are_preserved_for_mapping() {
+        let ts_content = r#"
+            type i64 = number;
+            type u64 = number;
+
+            export function ints(value: i64, ids: Set<u64>): Map<u64, i64> {
+                return new Map([[1, value]]);
+            }
+        "#;
+
+        let (functions, classes) = parse_script("test.ts", ts_content, false).unwrap();
+        assert!(classes.is_empty());
+        let function = functions
+            .iter()
+            .find(|function| function.name == "ints" && function.is_exported)
+            .unwrap();
+        assert_eq!(function.params[0].js_type.as_deref(), Some("i64"));
+        assert_eq!(function.params[0].rust_type.to_string(), "i64");
+        assert_eq!(function.params[1].js_type.as_deref(), Some("Set<u64>"));
+        assert_eq!(
+            function.params[1].rust_type.to_string(),
+            "&std::collections::HashSet<u64>"
+        );
+        assert_eq!(
+            function.rust_return_type.to_string(),
+            "std::collections::HashMap<u64, i64>"
         );
     }
 

--- a/dioxus-use-js/README.md
+++ b/dioxus-use-js/README.md
@@ -112,8 +112,6 @@ use_js!("source.ts", "bundle.js"::*);
 | --------------------- | ---------------- | ----------------- |
 | `string`              | `&str`           | `String`          |
 | `number`              | `f64`           | `f64`             |
-| `i64`                 | `i64`            | `i64`             |
-| `u64`                 | `u64`            | `u64`             |
 | `boolean`             | `bool`          | `bool`            |
 | `T \| null`           | `Option<&T>`     | `Option<T>`       |
 | `T[]`                 | `&[T]`           | `Vec<T>`          |
@@ -127,6 +125,8 @@ use_js!("source.ts", "bundle.js"::*);
 
 | TypeScript            | Rust Input       | Rust Output       |
 | --------------------- | ---------------- | ----------------- |
+| `i64`                 | `i64`            | `i64`             |
+| `u64`                 | `u64`            | `u64`             |
 | `Json`    | `&serde_json::Value` | `serde_json::Value` |
 | `JsValue<T>`, `JsValue`              | `&JsValue`       | `JsValue`         |
 | `RustCallback<T,TT>`     | `dioxus::core::Callback<T, impl Future<Output = Result<TT, serde_json::Value>> + 'static>` | `-`|
@@ -138,14 +138,16 @@ use_js!("source.ts", "bundle.js"::*);
 
 Special types are types not included in the regular Typescript type system, but are understood by the `use_js!` macro and may augment the generated binding code.
 
-For integer semantics on the Rust side, you can annotate with pseudo-types backed by TypeScript aliases:
+### Integars
+
+When an integar is specifically needed, rather than a float, one can explictly declare so.
 
 ```ts
 type i64 = number;
 type u64 = number;
 ```
 
-This keeps TypeScript happy with `number`, while generating `i64`/`u64` in Rust. Non-integer values will fail Rust deserialization.
+`i64`/`u64` will be used on the Rust side rather than `f64`. Note, non-integer values will fail deserialization.
 
 ### `Json`
 

--- a/dioxus-use-js/README.md
+++ b/dioxus-use-js/README.md
@@ -112,6 +112,8 @@ use_js!("source.ts", "bundle.js"::*);
 | --------------------- | ---------------- | ----------------- |
 | `string`              | `&str`           | `String`          |
 | `number`              | `f64`           | `f64`             |
+| `i64`                 | `i64`            | `i64`             |
+| `u64`                 | `u64`            | `u64`             |
 | `boolean`             | `bool`          | `bool`            |
 | `T \| null`           | `Option<&T>`     | `Option<T>`       |
 | `T[]`                 | `&[T]`           | `Vec<T>`          |
@@ -135,6 +137,15 @@ use_js!("source.ts", "bundle.js"::*);
 ## Special Types
 
 Special types are types not included in the regular Typescript type system, but are understood by the `use_js!` macro and may augment the generated binding code.
+
+For integer semantics on the Rust side, you can annotate with pseudo-types backed by TypeScript aliases:
+
+```ts
+type i64 = number;
+type u64 = number;
+```
+
+This keeps TypeScript happy with `number`, while generating `i64`/`u64` in Rust. Non-integer values will fail Rust deserialization.
 
 ### `Json`
 

--- a/dioxus-use-js/README.md
+++ b/dioxus-use-js/README.md
@@ -138,9 +138,9 @@ use_js!("source.ts", "bundle.js"::*);
 
 Special types are types not included in the regular Typescript type system, but are understood by the `use_js!` macro and may augment the generated binding code.
 
-### Integars
+### Integers
 
-When an integar is specifically needed, rather than a float, one can explictly declare so.
+When an integer is specifically needed rather than a float, one can explictly declare so.
 
 ```ts
 type i64 = number;


### PR DESCRIPTION
This adds support for i64 and u64 pseudo-types in the macro type mapper, so type i64 = number and type u64 = number produce integer Rust types instead of defaulting to f64. That fixes cases like Set elements and Map keys where floating-point Rust types are not useful. I also added test coverage for the new mappings and documented the alias pattern in the README.